### PR TITLE
Prevent the instance to hang at boot if the FS was corrupted

### DIFF
--- a/linuxrc
+++ b/linuxrc
@@ -607,7 +607,7 @@ do
                 # Resize $REAL_ROOT to fit the virtual drive
 		echo "Resizing $REAL_ROOT to fit the virtual drive"
                 /bin/growpart -v --fudge 20480 /dev/vda 1
-		e2fsck -f /dev/vda1
+		e2fsck -f -y /dev/vda1
 		resize2fs /dev/vda1
 
 		good_msg "Mounting $REAL_ROOT as root..."


### PR DESCRIPTION
e.g. :

/dev/vda1: recovering journal
Pass 1: Checking inodes, blocks, and sizes
Pass 2: Checking directory structure
Pass 3: Checking directory connectivity
Pass 4: Checking reference counts
Pass 5: Checking group summary information
Free blocks count wrong (1013426, counted=679344).
Fix<y>?
